### PR TITLE
Optimize custom importer

### DIFF
--- a/lib/sassc/embedded.rb
+++ b/lib/sassc/embedded.rb
@@ -187,7 +187,7 @@ module SassC
       Importer.new(@importer) if @importer
     end
 
-    class FileImporter
+    class FileSystemImporter
       class << self
         def resolve_path(path, from_import)
           ext = File.extname(path)
@@ -267,7 +267,7 @@ module SassC
       end
     end
 
-    private_constant :FileImporter
+    private_constant :FileSystemImporter
 
     class Importer
       def initialize(importer)
@@ -336,7 +336,7 @@ module SassC
         path = URL.file_urls_to_relative_path(url, parent_url)
         parent_path = URL.file_url_to_path(parent_url)
         [File.dirname(parent_path)].concat(load_paths).each do |load_path|
-          resolved = FileImporter.resolve_path(File.absolute_path(path, load_path), from_import)
+          resolved = FileSystemImporter.resolve_path(File.absolute_path(path, load_path), from_import)
           return URL.path_to_file_url(resolved) unless resolved.nil?
         end
         nil


### PR DESCRIPTION
This PR substantially improves the performance of custom importers that return paths without source contents, by using FileImporter to load file from disk directly on dart-sass side, instead of reading from on ruby side and then passing to dart-sass via protobuf.

The current [sass module resolution spec](https://github.com/sass/sass/blob/main/spec/modules.md#resolving-a-file-url) does not allow file extensions other than the standard `['.sass', '.scss', '.css']`. The dart-sass implementation does not resolve if a custom FileImporter returns a url with non-standard extension. However, loading of sass files with non-standard extensions is used in sprockets. Therefore, in such case we have to fallback to an Importer to read the file on ruby side.