### PR TITLE
Deprecate importing non-standard extensions from relative path or load paths

### DIFF
--- a/lib/sassc/embedded.rb
+++ b/lib/sassc/embedded.rb
@@ -235,10 +235,10 @@ module SassC
           unless ext.empty?
             if from_import
               result = exactly_one(try_path("#{without_ext(path)}.import#{ext}"))
-              return result unless result.nil?
+              return warn_deprecation_ext(result) unless result.nil?
             end
             result = exactly_one(try_path(path))
-            return result unless result.nil?
+            return warn_deprecation_ext(result) unless result.nil?
           end
 
           if from_import
@@ -296,6 +296,21 @@ module SassC
         def without_ext(path)
           ext = File.extname(path)
           path.delete_suffix(ext)
+        end
+
+        def warn_deprecation_ext(path)
+          basename = File.basename(path)
+          warn <<~WARNING
+            Deprecation Warning: Importing files with extensions other than `.scss`, `.sass`, `.css` from relative path or load paths without custom SassC::Importer is deprecated.
+
+            Recommandation: Rename #{basename} to #{basename}.scss
+
+            More info: https://github.com/sass-contrib/sassc-embedded-shim-ruby/pull/86
+
+            #{path}
+            #{' ' * (path.length - basename.length)}#{'^' * basename.length}
+          WARNING
+          path
         end
       end
     end


### PR DESCRIPTION
Background
=========

The current [sass module resolution spec](https://github.com/sass/sass/blob/main/spec/modules.md#resolving-a-file-url) does not allow file extensions other than the standard `.sass`, `.scss`, `.css`.

The `dart-sass` implementation has never supported non-standard extensions, but loading a file without a standard extension was supported in `sassc`, which would treat unknown extensions as `scss`. In order to support this,`load_paths` option is emulated by `sassc-embedded` on ruby side with custom importers instead of handled natively on dart side.

The `load_paths` emulation added complexity and had performance impact. This also created a rare bug: when both custom `SassC::Importer` and native `sass-embedded`/`dart-sass` `Importer` (e.g. `NodePkgImporter`) are provided, the load order would be wrong, that the emulated `load_paths` currently is attempted before additional native importers.

---

**Importing non-standard extensions via custom `SassC::Importer` is not affected and will continue to be supported.**

The only exception for non-standard extensions is when loading with a custom importer that directly load the file source contents. For example, in sprockets `foo.sass.erb` can be imported, because a custom rails importer would read the erb template, render it, and then return the render output as a string content.

Migration
=======

Rename files with non-standard extensions to add `.scss` extension.

---

Sample code and deprecation warning:

``` scss
@import "partials/explicit_extension_import.foo";
```

```
Deprecation Warning: Importing files with extensions other than `.scss`, `.sass`, `.css` from relative path or load paths without custom SassC::Importer is deprecated.

Recommandation: Rename _explicit_extension_import.foo to _explicit_extension_import.foo.scss

More info: https://github.com/sass-contrib/sassc-embedded-shim-ruby/pull/86

/build/app/assets/stylesheets/partials/_explicit_extension_import.foo
                                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
```