### PR TITLE
Prevent NotRenderedError when rendering empty file

### DIFF
--- a/lib/sassc/embedded.rb
+++ b/lib/sassc/embedded.rb
@@ -13,7 +13,10 @@ module SassC
     remove_method(:render) if public_method_defined?(:render, false)
 
     def render
-      return @template.dup if @template.empty?
+      if @template.empty?
+        @loaded_urls = []
+        return @template.dup 
+      end
 
       result = ::Sass.compile_string(
         @template,


### PR DESCRIPTION
@loaded_urls remains nil if the `@template` is "", and thus calling `dependencies` raises `NotRenderedError`, rather than returning empty array, as it should.